### PR TITLE
Issue #15: Container name is cached after logout

### DIFF
--- a/lib/services/userstore.js
+++ b/lib/services/userstore.js
@@ -9,14 +9,7 @@ define(['require'], function (require) {
       var tokenkey = 'LocalStorageUserStore.token';
       var hash = qs.decode($location.hash());
       var settings = {};
-      if (userkey in localStorage) {
-        try {
-          settings = JSON.parse(localStorage[userkey]);
-        } catch (e) {
-          // corrupt entry, let's clear it...
-          localStorage.removeItem(userkey);
-        }
-      }
+
       var regex = /^console_/;
       var toRemove = [];
       Object.getOwnPropertyNames(hash).forEach(function (propName) {


### PR DESCRIPTION
This PR resolves the issue where the container name is cached when visiting the kibana UI directly after previously linking to it from the webconsole.
