### PR TITLE
bug 1427274.  Allow consumers to override styles

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,6 +72,7 @@ module.exports = function (grunt) {
       }
     },
     clean: ['dist', releaseBase + '*'],
+    touch: ['dist/public/styles/overrides.css'],
     compress: {
       options: {
         pretty: true,
@@ -110,7 +111,8 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-compress');
   grunt.loadNpmTasks('grunt-github-releaser');
+  grunt.loadNpmTasks('grunt-touch');
 
-  grunt.registerTask('default', ['clean','less','copy']);
+  grunt.registerTask('default', ['clean','less','copy', 'touch']);
   grunt.registerTask('release', ['default', 'compress','github-release']);
 };

--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@ by this plugin are:
 
 * Origin skinning
 
+###
+Overriding Styles
+The plugin adds an empty stylesheet `$PLUGIN/public/styles/overrides.css' as a hook
+for users to modify the styles.  After deployment, you might wish to modify the header
+style to include a custer header logo:
+
+```
+.container-brand {
+  margin-top: 3px;
+  height: 11px;
+  background-image: url("../images/my-custom-image.svg");
+  background-size: 111px 11px;
+  background-repeat: no-repeat;
+}
+```
+This stylesheet is loaded after the main stylesheet provided by the plugin.
+
 Currently compatible with the 4.5.x code stream of Kibana
 
 ### Hacking the code

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-kibana",
-  "version": "0.6.2",
+  "version": "4.5.1-2",
   "homepage": "https://github.com/openshift/origin-kibana",
   "authors": [
     "dev@openshift.redhat.com"

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ export default function (kibana) {
     uiExports: {
       visTypes: [
         'plugins/origin-kibana/styles/main.css',
+        'plugins/origin-kibana/styles/overrides.css',
         'plugins/origin-kibana/directives',
         'plugins/origin-kibana/headerController',
         'plugins/origin-kibana/userstore',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-kibana",
-  "version": "4.5.1-1",
+  "version": "4.5.1-2",
   "homepage": "https://github.com/openshift/origin-kibana",
   "authors": [
     "dev@openshift.redhat.com"
@@ -26,11 +26,12 @@
     "bower": "^1.4.1",
     "grunt": "~0.4.5",
     "grunt-cli": "0.1.13",
-    "grunt-contrib-less": "~1.1.0",
-    "grunt-contrib-copy": "~0.8.2",
     "grunt-contrib-clean": "~0.7.0",
     "grunt-contrib-compress": "1.3.0",
-    "grunt-github-releaser": "~0.1.18"
+    "grunt-contrib-copy": "~0.8.2",
+    "grunt-contrib-less": "~1.1.0",
+    "grunt-github-releaser": "~0.1.18",
+    "grunt-touch": "^1.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@jwforres @spadgett  This should be enough to allow header and style customizations by the ops team right?  It provides an empty stylesheet that can be over-ridden.  Last one wins?